### PR TITLE
panic on missing SYSTEM_NAMESPACE

### DIFF
--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/serving/pkg/system"
+	_ "github.com/knative/serving/pkg/system/testing"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/testing/table.go
+++ b/pkg/reconciler/testing/table.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/kmeta"
+	_ "github.com/knative/serving/pkg/system/testing" // Setup system.Namespace()
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
+++ b/pkg/reconciler/v1alpha1/autoscaling/kpa/kpa_scaler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	clientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	fakeKna "github.com/knative/serving/pkg/client/clientset/versioned/fake"
+	_ "github.com/knative/serving/pkg/system/testing"
 	revisionresources "github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/revision/resources/names"
 	v1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/clusteringress_test.go
@@ -42,6 +42,7 @@ import (
 	fakeclientset "github.com/knative/serving/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/serving/pkg/client/informers/externalversions"
 	"github.com/knative/serving/pkg/reconciler"
+	_ "github.com/knative/serving/pkg/system/testing"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/config"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress/resources"
 	. "github.com/knative/serving/pkg/reconciler/v1alpha1/testing"

--- a/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
+++ b/pkg/reconciler/v1alpha1/clusteringress/resources/virtual_service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/knative/serving/pkg/apis/networking"
 	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving"
+	_ "github.com/knative/serving/pkg/system/testing"
 	"github.com/knative/serving/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
+++ b/pkg/reconciler/v1alpha1/route/resources/cluster_ingress_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/clusteringress"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/route/traffic"
+	"github.com/knative/serving/pkg/system"
+	_ "github.com/knative/serving/pkg/system/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -368,7 +370,7 @@ func TestMakeClusterIngressRule_InactiveTarget(t *testing.T) {
 			Paths: []netv1alpha1.HTTPClusterIngressPath{{
 				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 					ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-						ServiceNamespace: "knative-serving",
+						ServiceNamespace: system.Namespace(),
 						ServiceName:      "activator-service",
 						ServicePort:      intstr.FromInt(80),
 					},
@@ -420,7 +422,7 @@ func TestMakeClusterIngressRule_TwoInactiveTargets(t *testing.T) {
 			Paths: []netv1alpha1.HTTPClusterIngressPath{{
 				Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 					ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-						ServiceNamespace: "knative-serving",
+						ServiceNamespace: system.Namespace(),
 						ServiceName:      "activator-service",
 						ServicePort:      intstr.FromInt(80),
 					},

--- a/pkg/reconciler/v1alpha1/route/route_test.go
+++ b/pkg/reconciler/v1alpha1/route/route_test.go
@@ -331,7 +331,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 				Paths: []netv1alpha1.HTTPClusterIngressPath{{
 					Splits: []netv1alpha1.ClusterIngressBackendSplit{{
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-							ServiceNamespace: "knative-serving",
+							ServiceNamespace: system.Namespace(),
 							ServiceName:      "activator-service",
 							ServicePort:      intstr.FromInt(80),
 						},
@@ -510,7 +510,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 						Percent: 90,
 					}, {
 						ClusterIngressBackend: netv1alpha1.ClusterIngressBackend{
-							ServiceNamespace: "knative-serving",
+							ServiceNamespace: system.Namespace(),
 							ServiceName:      "activator-service",
 							ServicePort:      intstr.FromInt(80),
 						},

--- a/pkg/system/names.go
+++ b/pkg/system/names.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package system
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 const (
 	NamespaceEnvKey = "SYSTEM_NAMESPACE"
@@ -28,5 +31,22 @@ func Namespace() string {
 	if ns := os.Getenv(NamespaceEnvKey); ns != "" {
 		return ns
 	}
-	return "knative-serving"
+
+	panic(fmt.Sprintf(`The environment variable %q is not set
+
+If this is a process running on Kubernetes, then it should be using the downward
+API to initialize this variable via:
+
+  env:
+  - name: %s
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+
+If this is a Go unit test consuming system.Namespace() then it should add the
+following import:
+
+import (
+	_ "github.com/knative/serving/pkg/system/testing"
+)`, NamespaceEnvKey, NamespaceEnvKey))
 }

--- a/pkg/system/testing/names.go
+++ b/pkg/system/testing/names.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package names
+package testing
 
 import (
-	"github.com/knative/serving/pkg/apis/networking/v1alpha1"
+	"os"
+
+	"github.com/knative/serving/pkg/system"
 )
 
-// VirtualService returns the name of the VirtualService child resource for given ClusterIngress.
-func VirtualService(i *v1alpha1.ClusterIngress) string {
-	return i.Name
+func init() {
+	os.Setenv(system.NamespaceEnvKey, "knative-testing")
 }


### PR DESCRIPTION
This makes `pkg/system` panic if `SYSTEM_NAMESPACE` is not set.  For tests, it exposes a simple library you can link to set this variable to a suitable namespace.
